### PR TITLE
Bugfix on Zoom when image has Badges on it

### DIFF
--- a/Resources/views/layouts/default/page/layout.html.twig
+++ b/Resources/views/layouts/default/page/layout.html.twig
@@ -4,7 +4,7 @@
         badges is defined and
         badges|length
     %}
-        <div class="summa-product-badge-container">
+        <div class="summa-product-badge-container zoomContainer">
             {% set def_attr = attr %}
 
             {% for badge in badges %}


### PR DESCRIPTION
Added css class to solve bug when product has badges, the zoom functionality was breaking